### PR TITLE
Set the max version of `datasets` to v3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 accelerate
 bert_score
-datasets
+datasets<4
 einops
 evaluate
 openai


### PR DESCRIPTION
datasets v4 doesn't allow loading datasets from the Hugging Face Hub that run arbitrary code (as opposed to reading static data files), and thus reading MSMARCO fails with it. This change sets the max version to v3.