### PR TITLE
Fix that `InversionModel.from_pretrained` isn't tying the input and output embeddings

### DIFF
--- a/vec2text/models/inversion.py
+++ b/vec2text/models/inversion.py
@@ -128,6 +128,14 @@ class InversionModel(transformers.PreTrainedModel):
         self.embeddings_from_layer_n = embeddings_from_layer_n
         self.noise_level = vars(config).get("embedder_gaussian_noise_level")
 
+    # Without the following two method overrides, the weight-tying may fail, and the model outputs will be wrong.
+
+    def get_input_embeddings(self):
+        return self.encoder_decoder.get_input_embeddings()
+
+    def get_output_embeddings(self):
+        return self.encoder_decoder.get_output_embeddings()
+
     def _freeze_encoder(self):
         freeze_params(self.encoder_decoder.encoder)
 


### PR DESCRIPTION
When using the inversion model with a T5 encoder-decoder model created with `from_pretarined`, I was noticing having different results than when loading a trainer checkpoint. I pinpointed that the diff was that the former had the `encoder_decoder.lm_head` param set to zeros because the weight-tying was never called for it. [That happens during the model loading, and it's conditional on what methods the main model overrides.](https://github.com/huggingface/transformers/blob/v4.54.0/src/transformers/modeling_utils.py#L2946). This change ensures these methods are overridden.

Note that this param isn't included in the checkpoint file because it's part of the list `_tied_weights_keys` from T5. I'm not sure why it works fine when loading from a checkpoint.

I'm happy to also apply this change to other models in this codebase, but I'm unsure where else it's needed, as I'm not as familiar with it.